### PR TITLE
Add basic Bulma support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,6 +2302,11 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bulma": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.2.tgz",
+      "integrity": "sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ=="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "vue": "^2.5.17"
   },
   "devDependencies": {
-    "bootstrap": "^4.1.3",
+    "bootstrap": "4.1.3",
+    "bulma": "0.7.2",
     "@vue/cli-plugin-babel": "^3.1.1",
     "@vue/cli-plugin-eslint": "^3.1.5",
     "@vue/cli-plugin-unit-mocha": "^3.1.1",

--- a/src/BootstrapExample.vue
+++ b/src/BootstrapExample.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="container">
+        <h5 class="mb-4 font-weight-bold">Bootstrap Example Editor:</h5>
         <div class="row">
             <div class="col-8">
-                <h5>Bootstrap Example Editor:</h5>
                 <div class="card m-auto">
                     <div class="card-body">
                         <Vueson theme="bootstrap" ref="vuesonEditor" :schema='schema'></Vueson>

--- a/src/BulmaExample.vue
+++ b/src/BulmaExample.vue
@@ -1,7 +1,25 @@
 <template>
-    <div>
-        <h5>Bulma Example Editor:</h5>
-        <Vueson theme="bulma" ref="vuesonEditor" :schema='schema'></Vueson>
+    <div class="container">
+        <h5 class="title is-5">Bulma Example Editor:</h5>
+        <div class="tile is-ancestor">
+            <div class="tile is-vertical is-8">
+                <div class="tile is-parent">
+                    <article class="tile is-child notification">
+                        <div class="content">
+                            <Vueson theme="bulma" ref="vuesonEditor" :schema='schema'></Vueson>
+                        </div>
+                        <button  @click="showData" class="button is-link">Display Data</button>
+                    </article>
+                </div>
+            </div>
+            <div class="tile is-parent">
+                <article class="tile is-child notification is-dark is-paddingless">
+                    <div class="content">
+                        <pre class="has-background-dark has-text-white">{{displayData}}</pre>
+                    </div>
+                </article>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -25,5 +43,5 @@ export default {
 </script>
 
 <style scoped lang='scss'>
-    // TODO Add Material
+    @import "../node_modules/bulma/css/bulma.min.css";
 </style>

--- a/src/components/vueson/renderers/BooleanDisplay.vue
+++ b/src/components/vueson/renderers/BooleanDisplay.vue
@@ -7,12 +7,10 @@
             </label>
         </div>
 
-        <div v-else-if="theme === 'bulma'" class="form-check">
-            <input :name="propSchema.key" :id="id +'_' +propSchema.key" type="checkbox" v-model="inputValue">
-            <label :for="id +'_' +propSchema.key">
-                {{propSchema.title}}
-            </label>
-        </div>
+        <label class="checkbox" v-else-if="theme === 'bulma'">
+            <input :name="propSchema.key" :id="id +'_' +propSchema.key" v-model="inputValue" type="checkbox">
+            {{propSchema.title}}
+        </label>
 
         <div v-else-if="theme === 'material'" class="form-check">
             <input :name="propSchema.key" :id="id +'_' +propSchema.key" type="checkbox" v-model="inputValue">

--- a/src/components/vueson/renderers/NumberDisplay.vue
+++ b/src/components/vueson/renderers/NumberDisplay.vue
@@ -8,11 +8,17 @@
             </div>
         </div>
 
-        <div v-else-if="theme === 'bulma'">
-            <label :for="id +'_' +propSchema.key">{{propSchema.title}}</label>
-            <div>
-                <input type="number" v-model.number="inputValue" :id="id +'_' +propSchema.key" :name="propSchema.key">
-                <p><small>{{propSchema.description}}</small></p>
+        <div class="field is-horizontal" style="margin-bottom: 10px;" v-else-if="theme === 'bulma'">
+            <div class="field-label is-normal">
+                <label class="label" :for="id +'_' +propSchema.key">{{propSchema.title}}</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <p class="control">
+                        <input v-model="inputValue" :id="id +'_' +propSchema.key" :name="propSchema.key" class="input" type="number">
+                        <small class="has-text-grey-light">{{propSchema.description}}</small>
+                    </p>
+                </div>
             </div>
         </div>
 

--- a/src/components/vueson/renderers/StringDisplay.vue
+++ b/src/components/vueson/renderers/StringDisplay.vue
@@ -1,5 +1,8 @@
 <template>
     <div>
+        <!--
+        For Bootstrap
+        -->
         <div v-if="theme === 'bootstrap'" class="form-group row">
             <label :for="id +'_' +propSchema.key" class="col-sm-2 col-form-label">{{propSchema.title}}</label>
             <div class="col-sm-10">
@@ -8,14 +11,26 @@
             </div>
         </div>
 
-        <div v-else-if="theme === 'bulma'">
-            <label :for="id +'_' +propSchema.key">{{propSchema.title}}</label>
-            <div>
-                <input type="string" v-model="inputValue" :id="id +'_' +propSchema.key" :name="propSchema.key">
-                <p><small>{{propSchema.description}}</small></p>
+        <!--
+        For Bulma
+        -->
+        <div class="field is-horizontal" style="margin-bottom: 10px;" v-else-if="theme === 'bulma'">
+            <div class="field-label is-normal">
+                <label class="label" :for="id +'_' +propSchema.key">{{propSchema.title}}</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <p class="control">
+                        <input v-model="inputValue" :id="id +'_' +propSchema.key" :name="propSchema.key" class="input" type="text" >
+                        <small class="has-text-grey-light">{{propSchema.description}}</small>
+                    </p>
+                </div>
             </div>
         </div>
 
+        <!--
+        For Material
+        -->
         <div v-else-if="theme === 'material'">
             <label :for="id +'_' +propSchema.key">{{propSchema.title}}</label>
             <div>


### PR DESCRIPTION
This PR adds basic Bulma support.

Bulma:
<img width="1527" alt="screen shot 2018-12-10 at 3 43 57 pm" src="https://user-images.githubusercontent.com/43679573/49768857-ab0d4b00-fc92-11e8-8764-039a62aff62d.png">

Boostrap:
<img width="1530" alt="screen shot 2018-12-10 at 3 44 16 pm" src="https://user-images.githubusercontent.com/43679573/49768829-8f09a980-fc92-11e8-989d-d6037991daa0.png">


For record keeping progress of build size:
<img width="454" alt="screen shot 2018-12-10 at 3 41 40 pm" src="https://user-images.githubusercontent.com/43679573/49768737-3c2ff200-fc92-11e8-947d-4dd8c6f6c8e8.png">

